### PR TITLE
docs: add sample JSON output section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,75 @@ and [NVIDIA go-nvml](https://github.com/NVIDIA/go-nvml).
 All tools support MIG (Multi-Instance GPU) - MIG instances appear as separate
 devices with their parent GPU's shared metrics (temperature, power, PCIe).
 
+## Sample output
+
+Each tool returns structured JSON. The examples below show the shape of the
+data an agent receives from a node with two NVIDIA A100 GPUs.
+
+`list_gpus`:
+
+```json
+{
+  "count": 2,
+  "devices": [
+    {
+      "index": 0,
+      "uuid": "GPU-aaaa-1111",
+      "name": "NVIDIA A100-SXM4-80GB",
+      "gpu_utilization_percent": 85,
+      "memory_used_mib": 57344,
+      "memory_total_mib": 81920
+    },
+    {
+      "index": 1,
+      "uuid": "GPU-bbbb-2222",
+      "name": "NVIDIA A100-SXM4-80GB",
+      "gpu_utilization_percent": 20,
+      "memory_used_mib": 12288,
+      "memory_total_mib": 81920
+    }
+  ]
+}
+```
+
+`get_gpu_metrics` (with `{"index": 0}` or `{"uuid": "GPU-aaaa-1111"}`):
+
+```json
+{
+  "index": 0,
+  "uuid": "GPU-aaaa-1111",
+  "name": "NVIDIA A100-SXM4-80GB",
+  "gpu_utilization_percent": 85,
+  "memory_utilization_percent": 70,
+  "memory_used_mib": 57344,
+  "memory_total_mib": 81920,
+  "temperature_celsius": 72,
+  "power_draw_watts": 300,
+  "power_limit_watts": 400,
+  "pcie_tx_kbps": 0,
+  "pcie_rx_kbps": 0,
+  "nvlink_tx_mbps": 0,
+  "nvlink_rx_mbps": 0
+}
+```
+
+`gpu_summary`:
+
+```json
+{
+  "device_count": 2,
+  "avg_gpu_utilization": 52.5,
+  "avg_memory_utilization": 42.5,
+  "total_memory_used_mib": 69632,
+  "total_memory_total_mib": 163840,
+  "max_temperature_celsius": 72,
+  "total_power_draw_watts": 375
+}
+```
+
+MIG instances add `is_mig`, `parent_gpu`, and `mig_profile` fields to the
+`get_gpu_metrics` and `list_gpus` payloads.
+
 ## Quick start
 
 ```bash


### PR DESCRIPTION
## What does this PR do?

Adds a "Sample output" section to the README showing the JSON each tool returns (`list_gpus`, `get_gpu_metrics`, `gpu_summary`), so users know what data their agent receives. Values mirror the two-A100 mock fixture used in tests and were verified byte-for-byte against actual handler output.

## Related issues

Fixes #1

## Checklist

- [ ] Tests added/updated  <!-- docs only, no code -->
- [x] `make test` passes
- [ ] `make lint` passes    <!-- pre-existing errcheck in main.go, unrelated -->
- [x] Commits signed off (DCO)
