### PR TITLE
feat: add --version/-v flag to print build version

### DIFF
--- a/cmd/gpu-mcp-server/main.go
+++ b/cmd/gpu-mcp-server/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"log/slog"
 	"os"
@@ -30,6 +31,14 @@ import (
 var version = "dev"
 
 func main() {
+	for _, arg := range os.Args[1:] {
+		switch arg {
+		case "--version", "-v":
+			fmt.Println(version)
+			return
+		}
+	}
+
 	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, nil)))
 
 	collector, err := gpu.NewNVML()


### PR DESCRIPTION
## What does this PR do?

Adds a `--version` / `-v` flag. Parses `os.Args` before starting the server, prints the ldflags-injected `version` variable, and exits. No flag library — keeps it simple per the issue.

## Related issues

Fixes #3

## Checklist

- [ ] Tests added/updated  <!-- trivial arg parse; verified by running the built binary -->
- [x] `make test` passes
- [ ] `make lint` passes    <!-- pre-existing errcheck in main.go, unrelated -->
- [x] Commits signed off (DCO)