### PR TITLE
Add Cursor and Windsurf MCP config examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,36 @@ extensions:
     cmd: /path/to/gpu-mcp-server
 ```
 
+### Cursor
+
+Add to `.cursor/mcp.json` for a project, or `~/.cursor/mcp.json` for all
+projects:
+
+```json
+{
+  "mcpServers": {
+    "gpu": {
+      "type": "stdio",
+      "command": "/path/to/gpu-mcp-server"
+    }
+  }
+}
+```
+
+### Windsurf
+
+Add to `~/.codeium/windsurf/mcp_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "gpu": {
+      "command": "/path/to/gpu-mcp-server"
+    }
+  }
+}
+```
+
 ## Build
 
 Requires Go 1.23+, CGO, and NVIDIA drivers on the target machine.


### PR DESCRIPTION
## What does this PR do?

Adds MCP client configuration examples for:

- Cursor using `.cursor/mcp.json` or `~/.cursor/mcp.json`
- Windsurf using `~/.codeium/windsurf/mcp_config.json`

Both examples configure the local `gpu-mcp-server` binary over stdio.

## Related issues

Fixes #2

## Validation

- Parsed the added JSON snippets with PowerShell `ConvertFrom-Json`
- Ran `git diff --check`
- Not run: `make test` / `make lint` because `go` and `make` are not installed in this local environment

## Checklist

- [ ] Tests added/updated (N/A, docs-only)
- [ ] `make test` passes (not run locally; see validation note)
- [ ] `make lint` passes (not run locally; see validation note)
- [x] Commits signed off (DCO)