### PR TITLE
feat: add Helm chart for Kubernetes DaemonSet deployment

### DIFF
--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -35,6 +35,12 @@ jobs:
           helm template gpu-mcp deploy/helm/gpu-mcp-server --set transport=stdio > /dev/null
           helm template gpu-mcp deploy/helm/gpu-mcp-server --set serviceMonitor.enabled=true > /dev/null
 
+      - name: Install helm-unittest
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest --version v0.5.1
+
+      - name: helm unittest
+        run: helm unittest deploy/helm/gpu-mcp-server
+
   publish:
     # Package the chart and push it to GHCR as an OCI artifact on release.
     needs: lint

--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -1,0 +1,34 @@
+name: Helm
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "deploy/helm/**"
+      - ".github/workflows/helm.yaml"
+  pull_request:
+    paths:
+      - "deploy/helm/**"
+      - ".github/workflows/helm.yaml"
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: azure/setup-helm@v4
+        with:
+          version: v3.16.0
+
+      - name: helm lint
+        run: helm lint deploy/helm/gpu-mcp-server
+
+      - name: helm template (render)
+        run: |
+          helm template gpu-mcp deploy/helm/gpu-mcp-server > /dev/null
+          helm template gpu-mcp deploy/helm/gpu-mcp-server --set transport=stdio > /dev/null
+          helm template gpu-mcp deploy/helm/gpu-mcp-server --set serviceMonitor.enabled=true > /dev/null

--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -10,6 +10,8 @@ on:
     paths:
       - "deploy/helm/**"
       - ".github/workflows/helm.yaml"
+  release:
+    types: [published]
 
 permissions:
   contents: read
@@ -32,3 +34,27 @@ jobs:
           helm template gpu-mcp deploy/helm/gpu-mcp-server > /dev/null
           helm template gpu-mcp deploy/helm/gpu-mcp-server --set transport=stdio > /dev/null
           helm template gpu-mcp deploy/helm/gpu-mcp-server --set serviceMonitor.enabled=true > /dev/null
+
+  publish:
+    # Package the chart and push it to GHCR as an OCI artifact on release.
+    needs: lint
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: azure/setup-helm@v4
+        with:
+          version: v3.16.0
+
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Package chart
+        run: helm package deploy/helm/gpu-mcp-server --destination dist
+
+      - name: Push chart to GHCR
+        run: helm push dist/gpu-mcp-server-*.tgz oci://ghcr.io/${{ github.repository_owner }}/charts

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -26,7 +26,7 @@ Public roadmap for gpu-mcp-server. Updated quarterly.
 - [ ] Multi-node support aggregate metrics from remote hosts
 - [ ] GPU event notifications (thermal throttling, ECC errors, XID events)
 - [ ] OpenSSF Best Practices badge
-- [ ] Helm chart for Kubernetes deployment
+- [x] Helm chart for Kubernetes deployment
 
 ## Q2 2027
 

--- a/deploy/helm/gpu-mcp-server/.helmignore
+++ b/deploy/helm/gpu-mcp-server/.helmignore
@@ -1,0 +1,10 @@
+# Patterns to ignore when building Helm packages.
+.DS_Store
+.git/
+.gitignore
+*.tmproj
+*.bak
+*.swp
+*.orig
+.idea/
+.vscode/

--- a/deploy/helm/gpu-mcp-server/Chart.yaml
+++ b/deploy/helm/gpu-mcp-server/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+name: gpu-mcp-server
+description: A Helm chart to run gpu-mcp-server as a DaemonSet on Kubernetes GPU nodes
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+keywords:
+  - gpu
+  - nvidia
+  - nvml
+  - mcp
+  - monitoring
+home: https://github.com/pmady/gpu-mcp-server
+sources:
+  - https://github.com/pmady/gpu-mcp-server
+maintainers:
+  - name: gpu-mcp-server authors
+    url: https://github.com/pmady/gpu-mcp-server

--- a/deploy/helm/gpu-mcp-server/README.md
+++ b/deploy/helm/gpu-mcp-server/README.md
@@ -1,0 +1,88 @@
+# gpu-mcp-server Helm chart
+
+Deploys [gpu-mcp-server](https://github.com/pmady/gpu-mcp-server) as a
+`DaemonSet` on Kubernetes GPU nodes, so every GPU node exposes its NVIDIA
+metrics over MCP.
+
+## Prerequisites
+
+- Kubernetes 1.23+
+- NVIDIA drivers on the GPU nodes and the
+  [NVIDIA container toolkit](https://github.com/NVIDIA/k8s-device-plugin)
+  (for runtime driver injection)
+- Helm 3.8+
+
+## Install
+
+```bash
+helm install gpu-mcp deploy/helm/gpu-mcp-server \
+  --namespace gpu-monitoring --create-namespace
+```
+
+By default the chart runs the **http** transport and creates a `Service`, so
+the server is reachable in-cluster at
+`gpu-mcp-server.<namespace>.svc:8080`.
+
+## How it reaches the GPU
+
+The pod gets NVML access through the NVIDIA container runtime. The chart sets:
+
+- `NVIDIA_VISIBLE_DEVICES=all`
+- `NVIDIA_DRIVER_CAPABILITIES=utility` (metrics only — no compute/graphics)
+
+`utility` exposes NVML without reserving a GPU, so the DaemonSet does not
+consume allocatable `nvidia.com/gpu` capacity.
+
+If you do not use the NVIDIA runtime, mount the driver library from the host
+instead:
+
+```bash
+helm install gpu-mcp deploy/helm/gpu-mcp-server \
+  --set nvidia.runtimeInjection=false \
+  --set nvidia.hostMounts.enabled=true \
+  --set nvidia.hostMounts.libDir=/usr/lib/x86_64-linux-gnu
+```
+
+## Scheduling onto GPU nodes
+
+The chart tolerates the `nvidia.com/gpu` taint by default. Pin it to GPU nodes
+with a `nodeSelector` matching your cluster's labels, e.g.:
+
+```bash
+helm install gpu-mcp deploy/helm/gpu-mcp-server \
+  --set nodeSelector."nvidia\.com/gpu\.present"=true
+```
+
+## Sidecar (stdio) mode
+
+To run alongside an MCP client instead of as a network service:
+
+```bash
+helm install gpu-mcp deploy/helm/gpu-mcp-server --set transport=stdio
+```
+
+No `Service` or `ServiceMonitor` is created in stdio mode.
+
+## Prometheus
+
+A `ServiceMonitor` (Prometheus Operator) can be enabled with
+`--set serviceMonitor.enabled=true`. It requires the http transport. The
+`/metrics` path is reserved for a future metrics endpoint.
+
+## Key values
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `image.repository` | `ghcr.io/pmady/gpu-mcp-server` | Container image |
+| `image.tag` | chart `appVersion` | Image tag |
+| `transport` | `http` | `http` (standalone) or `stdio` (sidecar) |
+| `port` | `8080` | http listen port |
+| `nodeSelector` | `{}` | GPU node selector |
+| `tolerations` | `nvidia.com/gpu:NoSchedule` | GPU node taint tolerations |
+| `nvidia.runtimeInjection` | `true` | Use NVIDIA runtime to inject driver libs |
+| `nvidia.hostMounts.enabled` | `false` | Mount NVML library from the host instead |
+| `resources` | 50m/64Mi … 200m/128Mi | Container resource requests/limits |
+| `service.enabled` | `true` | Create a `Service` (http only) |
+| `serviceMonitor.enabled` | `false` | Create a Prometheus `ServiceMonitor` |
+
+See [values.yaml](values.yaml) for the full list.

--- a/deploy/helm/gpu-mcp-server/README.md
+++ b/deploy/helm/gpu-mcp-server/README.md
@@ -33,8 +33,8 @@ The pod gets NVML access through the NVIDIA container runtime. The chart sets:
 `utility` exposes NVML without reserving a GPU, so the DaemonSet does not
 consume allocatable `nvidia.com/gpu` capacity.
 
-If you do not use the NVIDIA runtime, mount the driver library from the host
-instead:
+If you do not use the NVIDIA runtime, mount the driver library **and the
+NVIDIA device nodes** from the host instead:
 
 ```bash
 helm install gpu-mcp deploy/helm/gpu-mcp-server \
@@ -42,6 +42,13 @@ helm install gpu-mcp deploy/helm/gpu-mcp-server \
   --set nvidia.hostMounts.enabled=true \
   --set nvidia.hostMounts.libDir=/usr/lib/x86_64-linux-gnu
 ```
+
+This mounts `libnvidia-ml.so` plus the device nodes NVML needs
+(`/dev/nvidiactl`, `/dev/nvidia-uvm`, `/dev/nvidia0`). Add a
+`/dev/nvidia<N>` entry under `nvidia.hostMounts.devices` for every GPU on the
+node. Accessing the device nodes usually requires relaxing the default
+`securityContext` (e.g. `--set securityContext.readOnlyRootFilesystem=false`)
+and may need the pod to run privileged depending on your node setup.
 
 ## Scheduling onto GPU nodes
 
@@ -80,7 +87,8 @@ A `ServiceMonitor` (Prometheus Operator) can be enabled with
 | `nodeSelector` | `{}` | GPU node selector |
 | `tolerations` | `nvidia.com/gpu:NoSchedule` | GPU node taint tolerations |
 | `nvidia.runtimeInjection` | `true` | Use NVIDIA runtime to inject driver libs |
-| `nvidia.hostMounts.enabled` | `false` | Mount NVML library from the host instead |
+| `nvidia.hostMounts.enabled` | `false` | Mount NVML library + device nodes from the host instead |
+| `nvidia.hostMounts.devices` | `nvidiactl, nvidia-uvm, nvidia0` | Host NVIDIA device nodes to expose |
 | `resources` | 50m/64Mi … 200m/128Mi | Container resource requests/limits |
 | `service.enabled` | `true` | Create a `Service` (http only) |
 | `serviceMonitor.enabled` | `false` | Create a Prometheus `ServiceMonitor` |

--- a/deploy/helm/gpu-mcp-server/templates/NOTES.txt
+++ b/deploy/helm/gpu-mcp-server/templates/NOTES.txt
@@ -1,0 +1,31 @@
+gpu-mcp-server has been deployed as a DaemonSet on your GPU nodes.
+
+Release:   {{ .Release.Name }}
+Namespace: {{ .Release.Namespace }}
+Transport: {{ .Values.transport }}
+
+Check the rollout:
+
+  kubectl -n {{ .Release.Namespace }} rollout status ds/{{ include "gpu-mcp-server.fullname" . }}
+  kubectl -n {{ .Release.Namespace }} get pods -l app.kubernetes.io/instance={{ .Release.Name }} -o wide
+
+{{- if eq .Values.transport "http" }}
+
+The server is reachable over HTTP on port {{ .Values.port }}.
+{{- if .Values.service.enabled }}
+
+Service: {{ include "gpu-mcp-server.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.service.port }}
+
+Port-forward and probe health locally:
+
+  kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "gpu-mcp-server.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }}
+  curl http://127.0.0.1:{{ .Values.service.port }}/healthz
+{{- end }}
+{{- else }}
+
+Running with the stdio transport (sidecar mode). Attach an MCP client to the
+container's stdio to use the GPU tools.
+{{- end }}
+
+If pods are Pending, confirm they tolerate your GPU node taints and that the
+nodeSelector/affinity in values.yaml matches your GPU node labels.

--- a/deploy/helm/gpu-mcp-server/templates/_helpers.tpl
+++ b/deploy/helm/gpu-mcp-server/templates/_helpers.tpl
@@ -1,0 +1,57 @@
+{{/* Expand the name of the chart. */}}
+{{- define "gpu-mcp-server.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this.
+*/}}
+{{- define "gpu-mcp-server.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/* Chart name and version as used by the chart label. */}}
+{{- define "gpu-mcp-server.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/* Common labels. */}}
+{{- define "gpu-mcp-server.labels" -}}
+helm.sh/chart: {{ include "gpu-mcp-server.chart" . }}
+{{ include "gpu-mcp-server.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/* Selector labels. */}}
+{{- define "gpu-mcp-server.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "gpu-mcp-server.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/* The name of the service account to use. */}}
+{{- define "gpu-mcp-server.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "gpu-mcp-server.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/* The image reference, defaulting the tag to the chart appVersion. */}}
+{{- define "gpu-mcp-server.image" -}}
+{{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
+{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- end }}

--- a/deploy/helm/gpu-mcp-server/templates/daemonset.yaml
+++ b/deploy/helm/gpu-mcp-server/templates/daemonset.yaml
@@ -95,6 +95,10 @@ spec:
             - name: nvml-lib
               mountPath: {{ .Values.nvidia.hostMounts.libDir }}
               readOnly: true
+            {{- range $i, $dev := .Values.nvidia.hostMounts.devices }}
+            - name: nvidia-dev-{{ $i }}
+              mountPath: {{ $dev }}
+            {{- end }}
           {{- end }}
       {{- if .Values.nvidia.hostMounts.enabled }}
       volumes:
@@ -102,6 +106,12 @@ spec:
           hostPath:
             path: {{ .Values.nvidia.hostMounts.libDir }}
             type: Directory
+        {{- range $i, $dev := .Values.nvidia.hostMounts.devices }}
+        - name: nvidia-dev-{{ $i }}
+          hostPath:
+            path: {{ $dev }}
+            type: CharDevice
+        {{- end }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/deploy/helm/gpu-mcp-server/templates/daemonset.yaml
+++ b/deploy/helm/gpu-mcp-server/templates/daemonset.yaml
@@ -1,0 +1,117 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "gpu-mcp-server.fullname" . }}
+  labels:
+    {{- include "gpu-mcp-server.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "gpu-mcp-server.selectorLabels" . | nindent 6 }}
+  updateStrategy:
+    {{- toYaml .Values.updateStrategy | nindent 4 }}
+  template:
+    metadata:
+      labels:
+        {{- include "gpu-mcp-server.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "gpu-mcp-server.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      {{- if and .Values.nvidia.runtimeInjection .Values.nvidia.runtimeClassName }}
+      runtimeClassName: {{ .Values.nvidia.runtimeClassName }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: gpu-mcp-server
+          image: {{ include "gpu-mcp-server.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            {{- if eq .Values.transport "http" }}
+            - --transport
+            - http
+            - --port
+            - {{ .Values.port | quote }}
+            {{- else }}
+            - --transport
+            - stdio
+            {{- end }}
+            {{- with .Values.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          env:
+            {{- if .Values.nvidia.runtimeInjection }}
+            - name: NVIDIA_VISIBLE_DEVICES
+              value: {{ .Values.nvidia.visibleDevices | quote }}
+            - name: NVIDIA_DRIVER_CAPABILITIES
+              value: {{ .Values.nvidia.driverCapabilities | quote }}
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- if eq .Values.transport "http" }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.port }}
+              protocol: TCP
+          {{- if .Values.probes.enabled }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 15
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 3
+            periodSeconds: 10
+          {{- end }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.nvidia.hostMounts.enabled }}
+          volumeMounts:
+            - name: nvml-lib
+              mountPath: {{ .Values.nvidia.hostMounts.libDir }}
+              readOnly: true
+          {{- end }}
+      {{- if .Values.nvidia.hostMounts.enabled }}
+      volumes:
+        - name: nvml-lib
+          hostPath:
+            path: {{ .Values.nvidia.hostMounts.libDir }}
+            type: Directory
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/helm/gpu-mcp-server/templates/daemonset.yaml
+++ b/deploy/helm/gpu-mcp-server/templates/daemonset.yaml
@@ -54,6 +54,7 @@ spec:
             {{- with .Values.extraArgs }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+          {{- if or .Values.nvidia.runtimeInjection .Values.extraEnv }}
           env:
             {{- if .Values.nvidia.runtimeInjection }}
             - name: NVIDIA_VISIBLE_DEVICES
@@ -64,6 +65,7 @@ spec:
             {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+          {{- end }}
           {{- if eq .Values.transport "http" }}
           ports:
             - name: http

--- a/deploy/helm/gpu-mcp-server/templates/service.yaml
+++ b/deploy/helm/gpu-mcp-server/templates/service.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.service.enabled (eq .Values.transport "http") -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "gpu-mcp-server.fullname" . }}
+  labels:
+    {{- include "gpu-mcp-server.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "gpu-mcp-server.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+{{- end }}

--- a/deploy/helm/gpu-mcp-server/templates/serviceaccount.yaml
+++ b/deploy/helm/gpu-mcp-server/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "gpu-mcp-server.serviceAccountName" . }}
+  labels:
+    {{- include "gpu-mcp-server.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/gpu-mcp-server/templates/servicemonitor.yaml
+++ b/deploy/helm/gpu-mcp-server/templates/servicemonitor.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.serviceMonitor.enabled -}}
+{{- if ne .Values.transport "http" -}}
+{{- fail "serviceMonitor.enabled requires transport: http" -}}
+{{- end -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "gpu-mcp-server.fullname" . }}
+  labels:
+    {{- include "gpu-mcp-server.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "gpu-mcp-server.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: http
+      path: {{ .Values.serviceMonitor.path }}
+      interval: {{ .Values.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+{{- end }}

--- a/deploy/helm/gpu-mcp-server/templates/tests/connection-test.yaml
+++ b/deploy/helm/gpu-mcp-server/templates/tests/connection-test.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.service.enabled (eq .Values.transport "http") }}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "gpu-mcp-server.fullname" . }}-test-connection
+  labels:
+    {{- include "gpu-mcp-server.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  containers:
+    - name: healthz
+      image: curlimages/curl:8.11.1
+      command: ["curl"]
+      args:
+        - --fail
+        - --silent
+        - --show-error
+        - http://{{ include "gpu-mcp-server.fullname" . }}:{{ .Values.service.port }}/healthz
+{{- end }}

--- a/deploy/helm/gpu-mcp-server/tests/daemonset_test.yaml
+++ b/deploy/helm/gpu-mcp-server/tests/daemonset_test.yaml
@@ -1,0 +1,110 @@
+suite: daemonset
+templates:
+  - templates/daemonset.yaml
+tests:
+  - it: renders a DaemonSet
+    asserts:
+      - isKind:
+          of: DaemonSet
+
+  - it: defaults the image tag to the chart appVersion
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/pmady/gpu-mcp-server:0.1.0
+
+  - it: uses http transport args by default
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --transport
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: http
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "8080"
+
+  - it: exposes the http container port
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].containerPort
+          value: 8080
+
+  - it: sets liveness and readiness probes on /healthz for http
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /healthz
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /healthz
+
+  - it: injects NVIDIA runtime env by default
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: NVIDIA_DRIVER_CAPABILITIES
+            value: utility
+
+  - it: tolerates the nvidia.com/gpu taint by default
+    asserts:
+      - contains:
+          path: spec.template.spec.tolerations
+          content:
+            key: nvidia.com/gpu
+            operator: Exists
+            effect: NoSchedule
+
+  - it: switches to stdio args when transport=stdio
+    set:
+      transport: stdio
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: stdio
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: http
+
+  - it: omits ports and probes in stdio mode
+    set:
+      transport: stdio
+    asserts:
+      - isNull:
+          path: spec.template.spec.containers[0].ports
+      - isNull:
+          path: spec.template.spec.containers[0].livenessProbe
+
+  - it: drops NVIDIA env when runtime injection is disabled
+    set:
+      nvidia.runtimeInjection: false
+    asserts:
+      - isNull:
+          path: spec.template.spec.containers[0].env
+
+  - it: mounts the nvml library and device nodes when host mounts are enabled
+    set:
+      nvidia.runtimeInjection: false
+      nvidia.hostMounts.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: nvml-lib
+            hostPath:
+              path: /usr/lib/x86_64-linux-gnu
+              type: Directory
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: nvidia-dev-0
+            hostPath:
+              path: /dev/nvidiactl
+              type: CharDevice
+
+  - it: has no host path volumes by default
+    asserts:
+      - isNull:
+          path: spec.template.spec.volumes

--- a/deploy/helm/gpu-mcp-server/tests/service_test.yaml
+++ b/deploy/helm/gpu-mcp-server/tests/service_test.yaml
@@ -1,0 +1,28 @@
+suite: service
+templates:
+  - templates/service.yaml
+tests:
+  - it: renders a ClusterIP Service in http mode
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: spec.type
+          value: ClusterIP
+      - equal:
+          path: spec.ports[0].targetPort
+          value: http
+
+  - it: is not rendered in stdio mode
+    set:
+      transport: stdio
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: is not rendered when service.enabled is false
+    set:
+      service.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/deploy/helm/gpu-mcp-server/tests/serviceaccount_test.yaml
+++ b/deploy/helm/gpu-mcp-server/tests/serviceaccount_test.yaml
@@ -1,0 +1,18 @@
+suite: serviceaccount
+templates:
+  - templates/serviceaccount.yaml
+tests:
+  - it: is created by default
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-gpu-mcp-server
+
+  - it: is not rendered when creation is disabled
+    set:
+      serviceAccount.create: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/deploy/helm/gpu-mcp-server/tests/servicemonitor_test.yaml
+++ b/deploy/helm/gpu-mcp-server/tests/servicemonitor_test.yaml
@@ -1,0 +1,26 @@
+suite: servicemonitor
+templates:
+  - templates/servicemonitor.yaml
+tests:
+  - it: is not rendered by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders a ServiceMonitor when enabled in http mode
+    set:
+      serviceMonitor.enabled: true
+    asserts:
+      - isKind:
+          of: ServiceMonitor
+      - equal:
+          path: spec.endpoints[0].port
+          value: http
+
+  - it: fails when enabled with a non-http transport
+    set:
+      serviceMonitor.enabled: true
+      transport: stdio
+    asserts:
+      - failedTemplate:
+          errorMessage: "serviceMonitor.enabled requires transport: http"

--- a/deploy/helm/gpu-mcp-server/values.yaml
+++ b/deploy/helm/gpu-mcp-server/values.yaml
@@ -1,0 +1,103 @@
+# Default values for gpu-mcp-server.
+
+image:
+  repository: ghcr.io/pmady/gpu-mcp-server
+  # tag defaults to the chart appVersion when empty.
+  tag: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+# Transport the server runs on.
+#   http  - standalone DaemonSet reachable over the network (default here)
+#   stdio - for running as a sidecar next to an MCP client
+transport: http
+
+# Port for the http transport (ignored when transport=stdio).
+port: 8080
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+
+podAnnotations: {}
+podLabels: {}
+
+# updateStrategy for the DaemonSet.
+updateStrategy:
+  type: RollingUpdate
+
+priorityClassName: ""
+
+# Pin the DaemonSet to GPU nodes. Default selector matches nodes labelled by
+# the NVIDIA GPU Operator / device plugin. Override for your cluster.
+nodeSelector: {}
+  # nvidia.com/gpu.present: "true"
+
+affinity: {}
+
+# Tolerate the taint the NVIDIA device plugin places on GPU nodes so the
+# DaemonSet is scheduled there.
+tolerations:
+  - key: nvidia.com/gpu
+    operator: Exists
+    effect: NoSchedule
+
+resources:
+  limits:
+    cpu: 200m
+    memory: 128Mi
+  requests:
+    cpu: 50m
+    memory: 64Mi
+
+podSecurityContext: {}
+securityContext:
+  # NVML only needs read access to the driver; run unprivileged.
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
+# How the container reaches NVML / the NVIDIA driver.
+nvidia:
+  # Let the NVIDIA container runtime inject the driver libraries (recommended).
+  # Requires the NVIDIA container toolkit / runtime class on the node.
+  runtimeInjection: true
+  visibleDevices: "all"
+  # "utility" is enough for NVML metrics; no compute/graphics capability needed.
+  driverCapabilities: "utility"
+  # runtimeClassName to request when runtimeInjection is enabled (optional).
+  runtimeClassName: ""
+  # Alternatively (or additionally) mount the NVML library from the host.
+  hostMounts:
+    enabled: false
+    # Directory on the host holding libnvidia-ml.so.
+    libDir: /usr/lib/x86_64-linux-gnu
+
+# Liveness/readiness probes hit /healthz (http transport only).
+probes:
+  enabled: true
+
+service:
+  enabled: true
+  type: ClusterIP
+  port: 8080
+  annotations: {}
+
+# Optional Prometheus Operator ServiceMonitor. Requires the http transport and
+# a metrics endpoint (the /metrics path is reserved for a future release).
+serviceMonitor:
+  enabled: false
+  interval: 30s
+  scrapeTimeout: 10s
+  path: /metrics
+  labels: {}
+
+# Extra environment variables and CLI args passed to the container.
+extraEnv: []
+extraArgs: []

--- a/deploy/helm/gpu-mcp-server/values.yaml
+++ b/deploy/helm/gpu-mcp-server/values.yaml
@@ -78,6 +78,13 @@ nvidia:
     enabled: false
     # Directory on the host holding libnvidia-ml.so.
     libDir: /usr/lib/x86_64-linux-gnu
+    # NVIDIA device nodes to expose so NVML can reach the driver when the
+    # NVIDIA runtime is not injecting them. Add /dev/nvidia<N> entries for each
+    # GPU on the node (nvidia0, nvidia1, ...).
+    devices:
+      - /dev/nvidiactl
+      - /dev/nvidia-uvm
+      - /dev/nvidia0
 
 # Liveness/readiness probes hit /healthz (http transport only).
 probes:


### PR DESCRIPTION
## What does this PR do?

Adds a Helm chart (`deploy/helm/gpu-mcp-server/`) to deploy gpu-mcp-server as a DaemonSet on Kubernetes GPU nodes, plus chart CI (lint, render, unit tests, and publish-on-release).

**Chart**
- DaemonSet — one server per GPU node; tolerates the `nvidia.com/gpu` taint, schedulable via an overridable nodeSelector/affinity
- NVML access in two modes:
  - NVIDIA container runtime injection (`NVIDIA_DRIVER_CAPABILITIES=utility`, so it does not reserve a GPU) — default
  - Host mounts — `libnvidia-ml.so` **and** the NVIDIA device nodes (`/dev/nvidiactl`, `/dev/nvidia-uvm`, `/dev/nvidia<N>`) as CharDevice volumes, for clusters without the NVIDIA runtime
- Configurable transport: `http` (standalone, with Service + `/healthz` liveness/readiness probes) or `stdio` (sidecar)
- Optional Prometheus `ServiceMonitor` (guarded to require http; `/metrics` reserved for a future endpoint)
- Values for image, resources, nodeSelector, tolerations, affinity, and securityContext (unprivileged, read-only rootfs, drops all caps by default)

**Tests**
- `helm-unittest` suite (20 assertions) across daemonset / service / servicemonitor / serviceaccount, including the stdio and host-mount paths and the ServiceMonitor non-http guard
- `helm test` connection Pod that curls `/healthz` through the Service

**CI** — new `.github/workflows/helm.yaml`: `helm lint` + render across scenarios + `helm-unittest` on chart changes; packages and pushes the chart to `oci://ghcr.io/<owner>/charts` on release.

## Related issues

Fixes #11
Relates to pmady/keda-gpu-scaler#100

## Checklist

- [x] Tests added/updated  <!-- helm-unittest suite (20 assertions, all pass) + helm test hook; wired into CI -->
- [x] `make test` passes    <!-- unaffected; chart-only change, no Go code -->
- [ ] `make lint` passes    <!-- pre-existing main.go errcheck, unrelated; helm lint passes clean -->
- [x] Commits signed off (DCO)

> **Note for maintainers:** this branch adds `.github/workflows/helm.yaml`