### PR TITLE
ci: create codeql workflow file for security scanning

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,9 +4,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-  # Commenting out for initial testing
-  # schedule:
-  #   - cron: '0 6 * * 1'
+  schedule:
+    - cron: '0 6 * * 1'
 
 permissions:
   contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,34 @@
+name: CodeQL
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  # Commenting out for initial testing
+  # schedule:
+  #   - cron: '0 6 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version: '1.25'
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          languages: go
+
+      - name: Build
+        run: CGO_ENABLED=1 go build -v ./cmd/gpu-mcp-server/
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,8 +4,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-  schedule:
-    - cron: '0 6 * * 1'
+  # schedule:
+  #   - cron: '0 6 * * 1'
 
 permissions:
   contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,8 +4,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-  # schedule:
-  #   - cron: '0 6 * * 1'
+  schedule:
+    - cron: '0 6 * * 1'
 
 permissions:
   contents: read


### PR DESCRIPTION
## What does this PR do?

Adds CodeQL security scanning workflow
- Builds on Ubuntu runner
- Uses:
    - actions/checkout v7.0.0
    - actions/setup-go v6.5.0
    - codeql-action/init v4.36.2
    - codeql-action/analyze v4.36.2
- All actions pinned to exact commit SHAs to prevent supply chain attacks via mutable tags
- Pinned Go version to 1.25 per go.mod
- Running go build with CGO_ENABLED=1 since cmd/gpu-mcp-server references go-nvml which uses C libraries
- Used https://github.com/pmady/keda-gpu-scaler/blob/main/.github/workflows/codeql.yaml as a reference / starting point.

## Verification
Commented out the schedule block for temporary verification against my own fork. 

No security vulnerabilities were found.
Upon merge to forked main confirmed that results are showing up in the security tab:
Fork: https://github.com/jasonp2323/gpu-mcp-server
Actions merge: https://github.com/jasonp2323/gpu-mcp-server/actions/runs/28336022514/job/83942266066
Security Tab: https://github.com/jasonp2323/gpu-mcp-server/security/code-scanning
Forked PR: https://github.com/jasonp2323/gpu-mcp-server/pull/1

## Related issues

This closes issue #40 

## Checklist

- [x] Adds security scanning to GitHub Actions workflow
- [ ] Tests added/updated
- [ ] `make test` passes
- [ ] `make lint` passes
- [x] Commits signed off (DCO)
