### PR TITLE
ci: publish docker image on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,12 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
@@ -53,6 +59,7 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           build-args: |
             VERSION=${{ github.ref_name }}
           tags: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.23"
+          go-version-file: go.mod
 
       - name: Run tests
         run: go test -v -race ./server/...

--- a/README.md
+++ b/README.md
@@ -172,6 +172,32 @@ make docker      # container image
 
 Tests use a mock collector, so they run anywhere no GPU hardware required.
 
+## Docker
+
+Prebuilt multi-arch images (linux/amd64, linux/arm64) are published to GHCR on every release.
+
+```bash
+docker pull ghcr.io/pmady/gpu-mcp-server:latest
+docker run --rm -i --gpus all ghcr.io/pmady/gpu-mcp-server:latest
+```
+
+The host needs the [NVIDIA Container Toolkit](https://github.com/NVIDIA/nvidia-container-toolkit)
+installed for `--gpus all` to work. The server speaks MCP over stdio, so the
+`-i` flag is required — don't drop it.
+
+```json
+{
+  "mcpServers": {
+    "gpu": {
+      "command": "docker",
+      "args": ["run", "--rm", "-i", "--gpus", "all", "ghcr.io/pmady/gpu-mcp-server:latest"]
+    }
+  }
+}
+```
+
+Pin a specific version via tag instead of `:latest`, e.g. `ghcr.io/pmady/gpu-mcp-server:v0.1.0`.
+
 ## Architecture
 
 ```


### PR DESCRIPTION
## What type of PR is this?

- [x] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Refactoring
- [x] CI/Build

## Description

Adds multi-architecture Docker image publishing to the release workflow and
documents container usage in the README. Also fixes a stale Go version pin
that has broken the release workflow since the go 1.25 bump.

**CI (`.github/workflows/release.yml`):**
- Added `docker/setup-qemu-action@v3` and `docker/setup-buildx-action@v3` steps to the existing `docker` job
- Added `platforms: linux/amd64,linux/arm64` to the `docker/build-push-action` step, so releases now publish multi-arch images to `ghcr.io/pmady/gpu-mcp-server` (arm64 covers Grace Hopper / GH200 GPU servers)
- Images remain tagged with both the release version (e.g. `v0.1.0`) and `latest`
- Fixed the release job's `setup-go` step, which pinned `go-version: "1.23"` while `go.mod` requires go >= 1.25 — with `GOTOOLCHAIN=local` this fails the test step, so any release tag pushed today would fail before building anything. Now uses `go-version-file: go.mod` so it can't drift again. (Found by rehearsing the release on my fork.)

**Docs (`README.md`):**
- New "Docker" section with `docker pull` / `docker run` examples, the NVIDIA Container Toolkit requirement for `--gpus all`, a note that `-i` is required since the server speaks MCP over stdio, and an MCP client config snippet that launches the server via `docker run`

**Testing — full release rehearsal on my fork:**
- Pushed a test tag; the release workflow ran end-to-end (binary release + docker job) and published to my fork's GHCR
- Verified via `docker buildx imagetools inspect` that the manifest list contains both `linux/amd64` and `linux/arm64`
- Verified both image variants boot: `--version` on the amd64 image natively and on the arm64 image under QEMU emulation
- Not yet exercised: NVML initialization on physical GPUs (`--gpus all`). I'm following up with a proposal for reusable GPU test infrastructure that will validate released images on real T4 (amd64) and T4G (arm64) hardware.
- Pushed a test tag; the release workflow ran end-to-end (binary release + docker job)
  and published to my fork's GHCR:
  [successful run](https://github.com/jasonp2323/gpu-mcp-server/actions/runs/28687681332)
  [published package](https://github.com/jasonp2323/gpu-mcp-server/pkgs/container/gpu-mcp-server)

## Related Issue

Fixes #27

## Checklist

- [ ] Tests added/updated (CI/docs change — no testable Go surface)
- [x] Documentation updated (if applicable)
- [x] `make test` passes
- [x] `make lint` passes
- [x] Commits are signed off (`git commit -s`)

## AI Assistance Disclosure
Per AI_GUIDELINES.md: the release.yml was modified with the help of AI
(Claude Code). I reviewed the changes, performed make and lint tests
and validated the release workflow by merging and tagging onto my own fork. 
Commits are DCO signed-off.

## Contributor Info

- **Name:** Jason Paquette
- **Location:** Boston, MA
- **Company / Affiliation:**